### PR TITLE
#243 RabbitMQ dependencies now declare queues for both dispatchers and consumers. Consumer and Dispatcher no longer close channel as it is handled by the RabbitMQ connection

### DIFF
--- a/src/Common/MlbTheShowForecaster.Common.Infrastructure/Messaging/RabbitMq/Dependencies.cs
+++ b/src/Common/MlbTheShowForecaster.Common.Infrastructure/Messaging/RabbitMq/Dependencies.cs
@@ -30,7 +30,9 @@ public static class Dependencies
         services.TryAddSingleton(connection);
 
         // Setup the RabbitMQ exchanges
-        SetupExchanges(connection, publisherDomainEventsToExchanges);
+        SetupExchanges(connection, publisherDomainEventsToExchanges.Concat(consumerDomainEventsToExchanges)
+            .GroupBy(x => x.Key)
+            .ToDictionary(k => k.Key, v => v.First().Value));
 
         // Add the channel as a transient factory so it creates a new channel for every service that requests it
         services.TryAddTransient<IModel>(sp => connection.CreateModel());

--- a/src/Common/MlbTheShowForecaster.Common.Infrastructure/Messaging/RabbitMq/RabbitMqDomainEventConsumer.cs
+++ b/src/Common/MlbTheShowForecaster.Common.Infrastructure/Messaging/RabbitMq/RabbitMqDomainEventConsumer.cs
@@ -83,6 +83,7 @@ public sealed class RabbitMqDomainEventConsumer<T> : IDisposable
     /// </summary>
     public void Dispose()
     {
-        _channel.Dispose();
+        // Calling Dispose/Abort/Close twice on RabbitMQ channel leads to null ref exception. Disposal is already handled by connection
+        //_channel.Dispose();
     }
 }

--- a/src/Common/MlbTheShowForecaster.Common.Infrastructure/Messaging/RabbitMq/RabbitMqDomainEventDispatcher.cs
+++ b/src/Common/MlbTheShowForecaster.Common.Infrastructure/Messaging/RabbitMq/RabbitMqDomainEventDispatcher.cs
@@ -14,7 +14,7 @@ public sealed class RabbitMqDomainEventDispatcher : IDomainEventDispatcher, IDis
     /// <summary>
     /// The RabbitMQ channel
     /// </summary>
-    private readonly IModel _model;
+    private readonly IModel _channel;
 
     /// <summary>
     /// A mapping of <see cref="IDomainEvent"/> types to their corresponding RabbitMQ exchanges
@@ -24,11 +24,11 @@ public sealed class RabbitMqDomainEventDispatcher : IDomainEventDispatcher, IDis
     /// <summary>
     /// Constructor
     /// </summary>
-    /// <param name="model">The RabbitMQ channel</param>
+    /// <param name="channel">The RabbitMQ channel</param>
     /// <param name="domainEventTypes">A mapping of <see cref="IDomainEvent"/> types to their corresponding RabbitMQ exchanges</param>
-    public RabbitMqDomainEventDispatcher(IModel model, Dictionary<Type, string> domainEventTypes)
+    public RabbitMqDomainEventDispatcher(IModel channel, Dictionary<Type, string> domainEventTypes)
     {
-        _model = model;
+        _channel = channel;
         _domainEventTypes = domainEventTypes;
     }
 
@@ -43,7 +43,7 @@ public sealed class RabbitMqDomainEventDispatcher : IDomainEventDispatcher, IDis
             var exchange = _domainEventTypes[e.GetType()];
             var routingKey = _domainEventTypes[e.GetType()];
 
-            _model.BasicPublish(exchange: exchange,
+            _channel.BasicPublish(exchange: exchange,
                 routingKey: routingKey,
                 body: Encoding.UTF8.GetBytes(JsonSerializer.Serialize(e, e.GetType()))
             );
@@ -55,6 +55,7 @@ public sealed class RabbitMqDomainEventDispatcher : IDomainEventDispatcher, IDis
     /// </summary>
     public void Dispose()
     {
-        _model.Dispose();
+        // Calling Dispose/Abort/Close twice on RabbitMQ channel leads to null ref exception. Disposal is already handled by connection
+        //_channel.Dispose();
     }
 }

--- a/tests/Common/MlbTheShowForecaster.Common.Infrastructure.Tests/Messaging/RabbitMq/DependenciesTests.cs
+++ b/tests/Common/MlbTheShowForecaster.Common.Infrastructure.Tests/Messaging/RabbitMq/DependenciesTests.cs
@@ -34,6 +34,7 @@ public class DependenciesTests
             { typeof(EventType1), "exA" },
             { typeof(EventType2), "exB" },
             { typeof(EventType3), "exC" },
+            { typeof(EventType4), "exD" },
         };
 
         // Mock channel
@@ -79,13 +80,16 @@ public class DependenciesTests
         mockChannel.Verify(x => x.ExchangeDeclare("exA", ExchangeType.Fanout, false, true, null), Times.Once);
         mockChannel.Verify(x => x.ExchangeDeclare("exB", ExchangeType.Fanout, false, true, null), Times.Once);
         mockChannel.Verify(x => x.ExchangeDeclare("exC", ExchangeType.Fanout, false, true, null), Times.Once);
+        mockChannel.Verify(x => x.ExchangeDeclare("exD", ExchangeType.Fanout, false, true, null), Times.Once);
         // Verify the queues were setup
         mockChannel.Verify(x => x.QueueDeclare("exA", true, false, true, null), Times.Once);
         mockChannel.Verify(x => x.QueueDeclare("exB", true, false, true, null), Times.Once);
         mockChannel.Verify(x => x.QueueDeclare("exC", true, false, true, null), Times.Once);
+        mockChannel.Verify(x => x.QueueDeclare("exD", true, false, true, null), Times.Once);
         mockChannel.Verify(x => x.QueueBind("exA", "exA", "exA", null), Times.Once);
         mockChannel.Verify(x => x.QueueBind("exB", "exB", "exB", null), Times.Once);
         mockChannel.Verify(x => x.QueueBind("exC", "exC", "exC", null), Times.Once);
+        mockChannel.Verify(x => x.QueueBind("exD", "exD", "exD", null), Times.Once);
 
         // The domain event dispatcher should be registered as a transient so it gets a new channel from the connection every time
         mockServices.Verify(s => s.Add(It.Is<ServiceDescriptor>(x =>

--- a/tests/Common/MlbTheShowForecaster.Common.Infrastructure.Tests/Messaging/RabbitMq/TestClasses/RabbitMqDomainEventsAndConsumers.cs
+++ b/tests/Common/MlbTheShowForecaster.Common.Infrastructure.Tests/Messaging/RabbitMq/TestClasses/RabbitMqDomainEventsAndConsumers.cs
@@ -8,6 +8,8 @@ public sealed record EventType2 : IDomainEvent;
 
 public sealed record EventType3 : IDomainEvent;
 
+public sealed record EventType4 : IDomainEvent;
+
 public sealed class DomainEventConsumer1 : IDomainEventConsumer<EventType1>
 {
     public Action? Callback { get; set; }


### PR DESCRIPTION
closes #243