### PR TITLE
#278 PlayerCard boosts and temporary ratings are now kept in sync by PlayerCardTracker

### DIFF
--- a/src/GameCards/Apps/MlbTheShowForecaster.GameCards.Apps.MarketplaceWatcher/MarketplaceWatcherHostExtensions.cs
+++ b/src/GameCards/Apps/MlbTheShowForecaster.GameCards.Apps.MarketplaceWatcher/MarketplaceWatcherHostExtensions.cs
@@ -42,7 +42,8 @@ public static class MarketplaceWatcherHostExtensions
                 var result = await tracker.TrackPlayerCards(SeasonYear.Create(season), ct);
                 logger.LogInformation($"{s} - Total catalog cards = {result.TotalCatalogCards}");
                 logger.LogInformation($"{s} - Total new catalog cards = {result.TotalNewCatalogCards}");
-                logger.LogInformation($"{s} - Total existing player cards = {result.TotalExistingPlayerCards}");
+                logger.LogInformation($"{s} - Total updated player cards = {result.TotalUpdatedPlayerCards}");
+                logger.LogInformation($"{s} - Total unchanged player cards = {result.TotalUnchangedPlayerCards}");
             }
         };
 

--- a/src/GameCards/MlbTheShowForecaster.GameCards.Application/Commands/UpdatePlayerCard/UpdatePlayerCardCommand.cs
+++ b/src/GameCards/MlbTheShowForecaster.GameCards.Application/Commands/UpdatePlayerCard/UpdatePlayerCardCommand.cs
@@ -13,7 +13,7 @@ namespace com.brettnamba.MlbTheShowForecaster.GameCards.Application.Commands.Upd
 /// <param name="PositionChange">The new position for the <see cref="PlayerCard"/></param>
 internal readonly record struct UpdatePlayerCardCommand(
     PlayerCard PlayerCard,
-    MlbPlayerCard? ExternalPlayerCard,
-    PlayerRatingChange? RatingChange,
-    PlayerPositionChange? PositionChange
+    MlbPlayerCard? ExternalPlayerCard = null,
+    PlayerRatingChange? RatingChange = null,
+    PlayerPositionChange? PositionChange = null
 ) : ICommand;

--- a/src/GameCards/MlbTheShowForecaster.GameCards.Application/Services/Results/PlayerCardTrackerResult.cs
+++ b/src/GameCards/MlbTheShowForecaster.GameCards.Application/Services/Results/PlayerCardTrackerResult.cs
@@ -1,14 +1,20 @@
-﻿namespace com.brettnamba.MlbTheShowForecaster.GameCards.Application.Services.Results;
+﻿using com.brettnamba.MlbTheShowForecaster.GameCards.Domain.Cards.Entities;
+
+namespace com.brettnamba.MlbTheShowForecaster.GameCards.Application.Services.Results;
 
 /// <summary>
 /// Represents the result of <see cref="IPlayerCardTracker.TrackPlayerCards"/>
 /// </summary>
 /// <param name="TotalCatalogCards">The total number of cards found in the external source <see cref="ICardCatalog"/></param>
 /// <param name="TotalNewCatalogCards">The number of cards present in the <see cref="ICardCatalog"/> but not present in the domain</param>
-public readonly record struct PlayerCardTrackerResult(int TotalCatalogCards, int TotalNewCatalogCards)
+/// <param name="TotalUpdatedPlayerCards">The number of <see cref="PlayerCard"/>s already present in the domain, but needed updating</param>
+public readonly record struct PlayerCardTrackerResult(
+    int TotalCatalogCards,
+    int TotalNewCatalogCards,
+    int TotalUpdatedPlayerCards)
 {
     /// <summary>
     /// The number player cards from <see cref="ICardCatalog"/> that already existed in the domain
     /// </summary>
-    public int TotalExistingPlayerCards => TotalCatalogCards - TotalNewCatalogCards;
+    public int TotalUnchangedPlayerCards => TotalCatalogCards - TotalNewCatalogCards - TotalUpdatedPlayerCards;
 }

--- a/src/GameCards/MlbTheShowForecaster.GameCards.Domain/Cards/Entities/PlayerCard.cs
+++ b/src/GameCards/MlbTheShowForecaster.GameCards.Domain/Cards/Entities/PlayerCard.cs
@@ -56,6 +56,11 @@ public sealed class PlayerCard : Card
     public bool IsBoosted => _historicalRatings.Any(x => x.IsBoost && !x.EndDate.HasValue);
 
     /// <summary>
+    /// True if the player card has a temporary rating
+    /// </summary>
+    public bool HasTemporaryRating => TemporaryOverallRating != null;
+
+    /// <summary>
     /// The start of the season for this card
     /// </summary>
     private DateOnly StartOfSeason => new(Year.Value, 1, 1);

--- a/tests/GameCards/MlbTheShowForecaster.GameCards.Application.Tests/TestClasses/Faker.cs
+++ b/tests/GameCards/MlbTheShowForecaster.GameCards.Application.Tests/TestClasses/Faker.cs
@@ -27,9 +27,10 @@ public static class Faker
     public static PlayerCard FakePlayerCard(ushort year = 2024, Guid? cardExternalId = null,
         CardType type = CardType.MlbCard, string image = "img.jpg", string name = "cardA",
         Rarity rarity = Rarity.Bronze, CardSeries series = CardSeries.Live, Position position = Position.RightField,
-        string teamShortName = "SEA", int overallRating = 50, PlayerCardAttributes? playerCardAttributes = null)
+        string teamShortName = "SEA", int overallRating = 50, PlayerCardAttributes? playerCardAttributes = null,
+        bool isBoosted = false, int? temporaryRating = null)
     {
-        return PlayerCard.Create(SeasonYear.Create(year),
+        var card = PlayerCard.Create(SeasonYear.Create(year),
             FakeCardExternalId(cardExternalId),
             type,
             CardImageLocation.Create(image),
@@ -40,6 +41,17 @@ public static class Faker
             TeamShortName.Create(teamShortName),
             OverallRating.Create(overallRating),
             playerCardAttributes ?? FakePlayerCardAttributes());
+
+        if (isBoosted)
+        {
+            card.Boost(new DateOnly(2024, 7, 17), FakePlayerCardAttributes());
+        }
+        else if (temporaryRating.HasValue)
+        {
+            card.SetTemporaryRating(new DateOnly(2024, 7, 17), FakeOverallRating(temporaryRating.Value));
+        }
+
+        return card;
     }
 
     public static PlayerCardHistoricalRating FakeBaselinePlayerCardHistoricalRating(DateOnly? startDate = null,


### PR DESCRIPTION
closes #278 