### PR TITLE
#360 Stat forecast impact changes with zero initial scores are no longer treated as an infinite improvement

### DIFF
--- a/src/GameCards/MlbTheShowForecaster.GameCards.Domain/Forecasts/ValueObjects/StatImpacts/StatsForecastImpact.cs
+++ b/src/GameCards/MlbTheShowForecaster.GameCards.Domain/Forecasts/ValueObjects/StatImpacts/StatsForecastImpact.cs
@@ -32,7 +32,7 @@ public abstract class StatsForecastImpact(decimal oldScore, decimal newScore, Da
     /// <summary>
     /// The percentage change between their old and new performance scores
     /// </summary>
-    public PercentageChange PercentageChange => PercentageChange.Create(OldScore, NewScore);
+    public PercentageChange PercentageChange => PercentageChange.Create(OldScore, NewScore, true);
 
     /// <summary>
     /// True if the new score is an improvement

--- a/tests/GameCards/MlbTheShowForecaster.GameCards.Domain.Tests/Forecasts/ValueObjects/StatImpacts/StatsForecastImpactTests.cs
+++ b/tests/GameCards/MlbTheShowForecaster.GameCards.Domain.Tests/Forecasts/ValueObjects/StatImpacts/StatsForecastImpactTests.cs
@@ -43,4 +43,18 @@ public class StatsForecastImpactTests
         // Assert
         Assert.Equal(Demand.Stable(), actual);
     }
+
+    [Fact]
+    public void PercentageChange_ZeroInitialScore_DoesNotDivideByZero()
+    {
+        // Arrange
+        var impact = Faker.FakeBattingStatsForecastImpact(oldScore: 0.0m, newScore: 0.11m);
+
+        // Act
+        var actual = impact.PercentageChange;
+
+        // Assert
+        Assert.Equal(11.0m, actual.PercentageChangeValue);
+        Assert.True(actual.TreatZeroReferenceValueAsOne);
+    }
 }


### PR DESCRIPTION
closes #360 