### PR TITLE
#449 Listing historical prices and orders now only allocate memory when displaying ordered data, no longer during queries

### DIFF
--- a/src/GameCards/MlbTheShowForecaster.GameCards.Application/Dtos/CardListing.cs
+++ b/src/GameCards/MlbTheShowForecaster.GameCards.Application/Dtos/CardListing.cs
@@ -39,7 +39,7 @@ public readonly record struct CardListing(
     /// <param name="domainListing">The domain <see cref="Listing"/></param>
     /// <returns>True if there are new historical prices for the <see cref="Listing"/></returns>
     public bool HasNewHistoricalPrices(Listing domainListing) => HistoricalPrices
-        .Any(x => !domainListing.HistoricalPricesChronologically.Select(y => y.Date).Contains(x.Date));
+        .Any(x => !domainListing.HistoricalPrices.Select(y => y.Date).Contains(x.Date));
 
     /// <summary>
     /// Returns true if this <see cref="CardListing"/> has orders that the domain <see cref="Listing"/>
@@ -48,9 +48,9 @@ public readonly record struct CardListing(
     /// <param name="domainListing">The domain <see cref="Listing"/></param>
     /// <returns>True if there are new orders for the <see cref="Listing"/></returns>
     public bool HasNewOrders(Listing domainListing) => RecentOrders.Any(x =>
-        domainListing.OrdersChronologically.Any(y =>
+        domainListing.Orders.Any(y =>
             x.Date == y.Date && x.Price.Value == y.Price.Value && x.Quantity.Value > y.Quantity.Value) ||
-        !domainListing.OrdersChronologically.Any(y => x.Date == y.Date && x.Price.Value == y.Price.Value));
+        !domainListing.Orders.Any(y => x.Date == y.Date && x.Price.Value == y.Price.Value));
 
     /// <summary>
     /// Returns new historical prices for the <see cref="Listing"/>
@@ -60,7 +60,7 @@ public readonly record struct CardListing(
     public IReadOnlyList<CardListingPrice> GetNewHistoricalPrices(Listing domainListing)
     {
         return HistoricalPrices
-            .Where(x => !domainListing.HistoricalPricesChronologically.Select(y => y.Date).Contains(x.Date))
+            .Where(x => !domainListing.HistoricalPrices.Select(y => y.Date).Contains(x.Date))
             .ToImmutableList();
     }
 
@@ -72,9 +72,9 @@ public readonly record struct CardListing(
     public IReadOnlyList<CardListingOrder> GetNewOrders(Listing domainListing)
     {
         return RecentOrders.Where(x =>
-                domainListing.OrdersChronologically.Any(y =>
+                domainListing.Orders.Any(y =>
                     x.Date == y.Date && x.Price.Value == y.Price.Value && x.Quantity.Value > y.Quantity.Value) ||
-                !domainListing.OrdersChronologically.Any(y => x.Date == y.Date && x.Price.Value == y.Price.Value))
+                !domainListing.Orders.Any(y => x.Date == y.Date && x.Price.Value == y.Price.Value))
             .ToImmutableList();
     }
 };

--- a/src/GameCards/MlbTheShowForecaster.GameCards.Domain/Marketplace/Entities/Listing.cs
+++ b/src/GameCards/MlbTheShowForecaster.GameCards.Domain/Marketplace/Entities/Listing.cs
@@ -46,10 +46,20 @@ public sealed class Listing : AggregateRoot
         _historicalPrices.OrderBy(x => x.Date).ToImmutableList();
 
     /// <summary>
+    /// The price history of this listing
+    /// </summary>
+    public IReadOnlyList<ListingHistoricalPrice> HistoricalPrices => _historicalPrices;
+
+    /// <summary>
     /// Orders for the listing in chronological order
     /// </summary>
     public IReadOnlyList<ListingOrder> OrdersChronologically =>
         _orders.OrderBy(x => x.Date).ThenByDescending(x => x.Price.Value).ToImmutableList();
+
+    /// <summary>
+    /// Orders for the listing
+    /// </summary>
+    public IReadOnlyList<ListingOrder> Orders => _orders;
 
     /// <summary>
     /// The total number of orders for the specified date

--- a/src/GameCards/MlbTheShowForecaster.GameCards.Infrastructure/Marketplace/EntityFrameworkCore/HybridNpgsqlEntityFrameworkCoreListingRepository.cs
+++ b/src/GameCards/MlbTheShowForecaster.GameCards.Infrastructure/Marketplace/EntityFrameworkCore/HybridNpgsqlEntityFrameworkCoreListingRepository.cs
@@ -214,7 +214,7 @@ public sealed class HybridNpgsqlEntityFrameworkCoreListingRepository : IListingR
     /// </summary>
     private readonly Action<Listing, NpgsqlBinaryImporter> _historicalPriceWriterDelegate = (listing, importer) =>
     {
-        foreach (var historicalPrice in listing.HistoricalPricesChronologically)
+        foreach (var historicalPrice in listing.HistoricalPrices)
         {
             importer.StartRow();
             importer.Write(listing.Id, NpgsqlDbType.Uuid);
@@ -229,7 +229,7 @@ public sealed class HybridNpgsqlEntityFrameworkCoreListingRepository : IListingR
     /// </summary>
     private readonly Action<Listing, NpgsqlBinaryImporter> _orderWriterDelegate = (listing, importer) =>
     {
-        foreach (var orderGroup in listing.OrdersChronologically.GroupBy(x => new { x.Date, x.Price.Value }))
+        foreach (var orderGroup in listing.Orders.GroupBy(x => new { x.Date, x.Price.Value }))
         {
             // Get the order with the highest quantity
             var order = orderGroup.OrderByDescending(x => x.Quantity.Value).First();

--- a/src/GameCards/MlbTheShowForecaster.GameCards.Infrastructure/Marketplace/EntityFrameworkCore/ListingEntityTypeConfiguration.cs
+++ b/src/GameCards/MlbTheShowForecaster.GameCards.Infrastructure/Marketplace/EntityFrameworkCore/ListingEntityTypeConfiguration.cs
@@ -60,7 +60,9 @@ public sealed class ListingEntityTypeConfiguration : IEntityTypeConfiguration<Li
 
         // Ignore these properties. They are not relationships/navigation properties, but just convenience methods for other members of the class
         builder.Ignore(x => x.HistoricalPricesChronologically);
+        builder.Ignore(x => x.HistoricalPrices);
         builder.Ignore(x => x.OrdersChronologically);
+        builder.Ignore(x => x.Orders);
 
         // Relation is defined on ListingHistoricalPrice end
         // builder.HasMany<ListingHistoricalPrice>("_historicalPrices")


### PR DESCRIPTION
closes #449 